### PR TITLE
logout dialog fixed, store userID in shared preference after acount c…

### DIFF
--- a/app/src/main/java/edu/northeastern/echolist/CreateAccountActivity.java
+++ b/app/src/main/java/edu/northeastern/echolist/CreateAccountActivity.java
@@ -3,6 +3,7 @@ package edu.northeastern.echolist;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.Gravity;
@@ -55,6 +56,11 @@ public class CreateAccountActivity extends AppCompatActivity {
 
         databaseReference.child(userId).setValue(newUser)
                 .addOnSuccessListener(aVoid -> {
+                    SharedPreferences sharedPreferences = getSharedPreferences("namePref", MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPreferences.edit();
+                    editor.putString("username", userId);
+                    editor.apply();
+
                     Intent intent = new Intent(CreateAccountActivity.this, HomeActivity.class);
                     startActivity(intent);
                     finish();

--- a/app/src/main/java/edu/northeastern/echolist/HomeActivity.java
+++ b/app/src/main/java/edu/northeastern/echolist/HomeActivity.java
@@ -97,13 +97,17 @@ public class HomeActivity extends AppCompatActivity {
     // Logout confirmation Dialog from Home page.
     @Override
     public void onBackPressed() {
-        super.onBackPressed();
         new AlertDialog.Builder(this)
                 .setMessage("Do you want to log out?")
                 .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         FirebaseAuth.getInstance().signOut();
+                        SharedPreferences sharedPreferences = getSharedPreferences("namePref", MODE_PRIVATE);
+                        SharedPreferences.Editor editor = sharedPreferences.edit();
+                        editor.clear();
+                        editor.apply();
+
                         Intent intent = new Intent(HomeActivity.this, SignInActivity.class);
                         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                         startActivity(intent);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,13 @@
 buildscript {
+    repositories {
+        google()
+    }
+
     dependencies {
         classpath("com.google.gms:google-services:4.4.1")
     }
 }
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.3.1" apply false
+    id("com.android.application") version "8.2.1" apply false
 }


### PR DESCRIPTION
1. Logout Dialog updated to delete all user object from home activity.
2.  Store userID in shared preference after account creating


Testing instruction : 
1. Create a new account and verify that your username is displayed in the top right corner of the HomeActivity screen.
2. Sign out and sign back in with the same account you just created. Check if the username is still correctly displayed in the top right corner.
3. Log out, create a new account with a different username, and verify that the username displayed in the top right corner has been updated to reflect the new account.
